### PR TITLE
add simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:2.7.8-onbuild
+CMD [ "python", "datapusher/main.py", "deployment/datapusher_settings.py"]


### PR DESCRIPTION
Given the current state of ckan core's contrib/docker, and the existing PRs
a non-controversial and useful next-step would be to add a basic Dockerfile to this repo.
Any additional work in the other PRs can be done on top of this.

Current state of DataPusher:
ckan core's Docker contrib uses a 3rd party repo that has a basic
Dockerfile
https://github.com/ckan/ckan/blob/master/contrib/docker/docker-compose.yml#L44
https://github.com/clementmouchet/datapusher/blob/master/Dockerfile
To stop using that 3rd party repo we only need this Dockerfile.

There exists a PR for adding this Dockerfile, and a docker-compose.yml.
The Dockerfile is required for Docker contrib's docker-compose.yml to
work.
https://github.com/ckan/datapusher/pull/136
The docker-compose.yml may be required for when a user wants to
break the datapusher out on to another machine, but they could also
just copy the relevant section from ckan core or use the example
from the other PR.

There exists another PR for running Datapusher behind it's own version
of Apache, this is super useful, but is a very specific architecture choice.
I'm glad the PR is there, but it may be too specific to add to the plugin repo as the default.
https://github.com/ckan/datapusher/pull/110